### PR TITLE
Add dataProvider to dataset migration

### DIFF
--- a/config/rules.php
+++ b/config/rules.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 $classMethodAnalyzer = new \Pest\Drift\Analyzer\ClassMethodAnalyzer();
 $nodeFinder = new \PhpParser\NodeFinder();
+$phpDocTagExtractor = new \Pest\Drift\Extractor\PhpDocTagExtractor();
 
 return [
+    new \Pest\Drift\NodeDecorator\PhpDocTagDecorator($phpDocTagExtractor),
+    new \Pest\Drift\NodeDecorator\DataProviderDecorator($nodeFinder, $phpDocTagExtractor),
     new \Pest\Drift\Rules\RemoveClass(),
     new \Pest\Drift\Rules\RemoveNamespace(),
     new \Pest\Drift\Rules\ExtendsToUses(),

--- a/src/Analyzer/ClassMethodAnalyzer.php
+++ b/src/Analyzer/ClassMethodAnalyzer.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Drift\Analyzer;
 
-use PhpParser\Comment;
+use Pest\Drift\ValueObject\Node\AttributeKey;
+use Pest\Drift\ValueObject\PhpDoc\TagKey;
 use PhpParser\Node\Stmt\ClassMethod;
 
 /**
@@ -30,20 +31,17 @@ final class ClassMethodAnalyzer implements ClassMethodAnalyzerInterface
      */
     public function isTestMethod(ClassMethod $classMethod): bool
     {
-        $comments = $classMethod->getComments();
-
-        return str_starts_with($classMethod->name->toString(), 'test') || $this->containsTestAnnotation($comments);
+        return str_starts_with($classMethod->name->toString(), 'test') || $this->containsTestAnnotation($classMethod);
     }
 
     /**
      * Search @test annotations in comments.
-     *
-     * @param  array<int, Comment>  $comments
      */
-    private function containsTestAnnotation(array $comments): bool
+    private function containsTestAnnotation(ClassMethod $classMethod): bool
     {
-        $testAnnotations = array_filter($comments, static fn (Comment $comment): bool => str_contains($comment->getText(), '@test'));
+        /** @var array<string, array<int, string>> $phpDocTags */
+        $phpDocTags = $classMethod->getAttribute(AttributeKey::PHP_DOC_TAGS, []);
 
-        return $testAnnotations !== [];
+        return array_key_exists(TagKey::TEST, $phpDocTags);
     }
 }

--- a/src/Extractor/PhpDocTagExtractor.php
+++ b/src/Extractor/PhpDocTagExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\Extractor;
+
+use PhpParser\Comment;
+
+final class PhpDocTagExtractor
+{
+    /**
+     * @param  array<int, Comment>  $comments
+     * @return  array<string, array<int, string>>
+     */
+    public function fromComments(array $comments): array
+    {
+        $tags = [];
+
+        foreach ($comments as $comment) {
+            preg_match_all('/(@[^\s\n]*) ?([^\s\n]*) *$/m', $comment->getText(), $matches);
+            $itemsCount = is_countable($matches[1]) ? count($matches[1]) : 0;
+
+            for ($i = 0; $i < $itemsCount; $i++) {
+                $key = (string) $matches[1][$i];
+                $value = (string) $matches[2][$i];
+
+                if (! array_key_exists($key, $tags)) {
+                    $tags[$key] = [];
+                }
+
+                $tags[$key][] = $value;
+            }
+        }
+
+        return $tags;
+    }
+}

--- a/src/NodeDecorator/DataProviderDecorator.php
+++ b/src/NodeDecorator/DataProviderDecorator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\NodeDecorator;
+
+use Pest\Drift\Extractor\PhpDocTagExtractor;
+use Pest\Drift\ValueObject\Node\AttributeKey;
+use Pest\Drift\ValueObject\PhpDoc\TagKey;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeVisitorAbstract;
+
+final class DataProviderDecorator extends NodeVisitorAbstract
+{
+    /**
+     * @var string[]
+     */
+    private array $dataProviders = [];
+
+    public function __construct(private readonly NodeFinder $nodeFinder, private readonly PhpDocTagExtractor $phpDocTagExtractor)
+    {
+    }
+
+    public function beforeTraverse(array $nodes)
+    {
+        /** @var array<int, ClassMethod>  $classMethods */
+        $classMethods = $this->nodeFinder->findInstanceOf($nodes, ClassMethod::class);
+
+        foreach ($classMethods as $classMethod) {
+            $phpDocTags = $this->phpDocTagExtractor->fromComments($classMethod->getComments());
+            $dataProviders = $phpDocTags[TagKey::DATA_PROVIDER] ?? [];
+            $this->dataProviders = [...$this->dataProviders, ...$dataProviders];
+        }
+
+        return parent::beforeTraverse($nodes);
+    }
+
+    public function enterNode(Node $node)
+    {
+        if (! $node instanceof ClassMethod) {
+            return null;
+        }
+
+        $node->setAttribute(AttributeKey::IS_DATA_PROVIDER, in_array($node->name->toString(), $this->dataProviders, true));
+    }
+}

--- a/src/NodeDecorator/PhpDocTagDecorator.php
+++ b/src/NodeDecorator/PhpDocTagDecorator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\NodeDecorator;
+
+use Pest\Drift\Extractor\PhpDocTagExtractor;
+use Pest\Drift\ValueObject\Node\AttributeKey;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeVisitorAbstract;
+
+final class PhpDocTagDecorator extends NodeVisitorAbstract
+{
+    public function __construct(private readonly PhpDocTagExtractor $phpDocTagExtractor)
+    {
+    }
+
+    public function enterNode(Node $node)
+    {
+        if (! $node instanceof ClassMethod) {
+            return null;
+        }
+
+        $node->setAttribute(AttributeKey::PHP_DOC_TAGS, $this->phpDocTagExtractor->fromComments($node->getComments()));
+    }
+}

--- a/src/ValueObject/Node/AttributeKey.php
+++ b/src/ValueObject/Node/AttributeKey.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\ValueObject\Node;
+
+final class AttributeKey
+{
+    public const PHP_DOC_TAGS = 'phpDoctags';
+
+    public const IS_DATA_PROVIDER = 'isDataProvider';
+}

--- a/src/ValueObject/PhpDoc/TagKey.php
+++ b/src/ValueObject/PhpDoc/TagKey.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\ValueObject\PhpDoc;
+
+final class TagKey
+{
+    public const TEST = '@test';
+
+    public const DEPENDS = '@depends';
+
+    public const DATA_PROVIDER = '@dataProvider';
+}

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -336,6 +336,42 @@ test('login screen can be rendered', function () {
     expect($convertedCode)->toEqual($expected);
 });
 
+it('convert data providers to dataset', function () {
+    $code = '<?php
+
+use Tests\TestCase;
+
+class ExampleTest extends TestCase
+{
+    /**
+     * @dataProvider emailProvider
+     */
+    public function testHasEmails(string $email)
+    {
+    }
+
+    public function emailProvider()
+    {
+        return ["example@example.com", "other@example.com"];
+    }
+}
+';
+
+    $convertedCode = codeConverter()->convert($code);
+
+    $expected = '<?php
+
+test(\'has emails\', function (string $email) {
+})->with(\'emailProvider\');
+
+dataset(\'emailProvider\', function () {
+    return ["example@example.com", "other@example.com"];
+});
+';
+
+    expect($convertedCode)->toEqual($expected);
+});
+
 it('convert assertEquals to Pest expectation', function () {
     $code = '<?php
         class MyTest {


### PR DESCRIPTION
Resolve #11 

For the moment, the migrated datasets are at the same location where the data providers were and are defined by the `dataset`  call. In other words, datasets are not directly defined in the `with` call and are not defined in a specific `Datasets.php` file or in `tests/Datasets` folder. You can see an example on the test added.

I think that this is a first version and that these points will have to be made, but it will mean slightly revising the way the plugin works and taking a little more time.

Tell me if it's still okay.