### PR TITLE
Fix assertJson Method Conflict in PHPUnit to Pest Conversion for Laravel Project

### DIFF
--- a/config/rules.php
+++ b/config/rules.php
@@ -63,7 +63,7 @@ return [
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertDirectoryIsReadable', 'toBeReadableDirectory', 2),
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertDirectoryIsWritable', 'toBeWritableDirectory', 2),
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertNan', 'toBeNan', 2),
-    new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertJson', 'toBeJson', 2),
+    new \Pest\Drift\Rules\Assertions\AssertJsonToExpectation(),
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertIsScalar', 'toBeScalar', 2),
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertIsResource', 'toBeResource', 2),
     new \Pest\Drift\Rules\Assertions\AssertionToExpectation('assertIsObject', 'toBeObject', 2),

--- a/src/Rules/Assertions/AbstractAssertionToExpectation.php
+++ b/src/Rules/Assertions/AbstractAssertionToExpectation.php
@@ -61,7 +61,7 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
      * @param  array<Arg|VariadicPlaceholder>  $args
      * @return array<Arg|VariadicPlaceholder>
      */
-    private function expected(array $args): array
+    protected function expected(array $args): array
     {
         $actualPosition = $this->argumentCount >= 3 ? 1 : 0;
 
@@ -75,7 +75,7 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
      *
      * @param  array<Arg|VariadicPlaceholder>  $args
      */
-    private function actual(array $args): Arg|VariadicPlaceholder
+    protected function actual(array $args): Arg|VariadicPlaceholder
     {
         $actualPosition = $this->argumentCount >= 3 ? 1 : 0;
 

--- a/src/Rules/Assertions/AssertJsonToExpectation.php
+++ b/src/Rules/Assertions/AssertJsonToExpectation.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Pest\Drift\Rules\Assertions;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\MethodCall;
+
+class AssertJsonToExpectation extends AbstractAssertionToExpectation
+{
+    protected bool $isPhpUnitAssertJsonCall;
+
+    public function __construct()
+    {
+        parent::__construct('assertJson', 'assertJson|toBeJson', 2);
+    }
+
+    protected function buildExpect(MethodCall $methodCall): Expr
+    {
+        $this->setIsPhpUnitAssertJsonCall($methodCall->var->name == 'this');
+
+        $this->setNewName();
+
+        return new FuncCall(
+            new Name('expect'),
+            [
+                $this->actual(
+                    $this->getArgumentsBasedOnAssertJsonType($methodCall)
+                ),
+            ]
+        );
+    }
+
+    protected function expected(array $args): array
+    {
+        return $this->isPhpUnitAssertJsonCall ? parent::expected($args) : $args;
+    }
+
+    private function getArgumentsBasedOnAssertJsonType(MethodCall $methodCall): array
+    {
+        return $this->isPhpUnitAssertJsonCall
+            ? $methodCall->args
+            : [new Arg(new Variable($methodCall->var->name))];
+    }
+
+    private function setIsPhpUnitAssertJsonCall(bool $isPhpUnitAssertJsonCall): void
+    {
+        $this->isPhpUnitAssertJsonCall = $isPhpUnitAssertJsonCall;
+    }
+
+    private function setNewName(): void
+    {
+        $this->newName = $this->isPhpUnitAssertJsonCall ? 'toBeJson' : 'assertJson';
+    }
+}

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -971,6 +971,104 @@ it('convert assertJson to PestExpectation', function () {
     expect($convertedCode)->toContain('expect(1)->toBeJson()');
 });
 
+it('convert assertJson that use the non phpunit assertJson to PestExpectation', function(){
+    $code = <<<'CODE'
+<?php
+class MyTest {
+    public function test_can_store_some_stuff()
+    {
+        $data = ["name" => "ali"];
+
+        $response = $this->postJson(route("users.store"), $data);
+
+        $response->assertCreated();
+
+        $response->assertJson([
+            "data" => [
+                "name" => $data["name"]
+            ]
+        ]);
+    }
+}
+CODE;
+
+    $expectedCode = <<<'CODE'
+<?php
+test('can store some stuff', function () {
+    $data = ["name" => "ali"];
+
+    $response = $this->postJson(route("users.store"), $data);
+
+    $response->assertCreated();
+
+    expect($response)->assertJson([
+        "data" => [
+            "name" => $data["name"]
+        ]
+    ]);
+});
+CODE;
+
+    $convertedCode = codeConverter()->convert($code);
+
+    expect($convertedCode)->toBe($expectedCode);
+});
+
+it('convert assertJson that use the phpunit with non phpunit assertJson to PestExpectation', function(){
+    $code = <<<'CODE'
+<?php
+class MyTest {
+    public function test_can_store_some_stuff()
+    {
+        $data = ["name" => "ali"];
+
+        $response = $this->postJson(route("users.store"), $data);
+
+        $response->assertCreated();
+        
+        $this->assertJson([
+             "data" => [
+                    "name" => $data["name"]
+                ]
+        ]);
+
+        $response->assertJson([
+            "data" => [
+                "name" => $data["name"]
+            ]
+        ]);
+    }
+}
+CODE;
+
+    $expectedCode = <<<'CODE'
+<?php
+test('can store some stuff', function () {
+    $data = ["name" => "ali"];
+
+    $response = $this->postJson(route("users.store"), $data);
+
+    $response->assertCreated();
+
+    expect([
+         "data" => [
+                "name" => $data["name"]
+            ]
+    ])->toBeJson();
+
+    expect($response)->assertJson([
+        "data" => [
+            "name" => $data["name"]
+        ]
+    ]);
+});
+CODE;
+
+    $convertedCode = codeConverter()->convert($code);
+
+    expect($convertedCode)->toBe($expectedCode);
+});
+
 it('convert assertNan to PestExpectation', function () {
     $code = '<?php
         class MyTest {


### PR DESCRIPTION
Hey :wave:,

First and foremost, I'd like to express my appreciation to the Pest team for developing the drift plugin, which has been invaluable for transitioning a large number of PHPUnit tests to this fantastic wrapper :rose:.

However, I've encountered a bug with the plugin, specifically in scenarios where I've used the drift plugin to convert legacy PHPUnit tests into Pest syntax in Laravel projects. Unfortunately, this has resulted in several test failures :fearful:.

### Let's Dive into the Issue with Some Code

```php
<?php

use Illuminate\Foundation\Testing\TestCase;

class UserCreationTest extends TestCase
{
    public function test_can_store_user_data()
    {
        $data = ["name" => "ali"];

        $response = $this->postJson(route("users.store"), $data);

        $response->assertCreated();

        $response->assertJson([
            "data" => [
                "name" => $data["name"]
            ]
        ]);
    }
}
```

#### Our Expected Outcome ✅
We anticipate that after converting this test into the code below:

```php
<?php

test('can store user data', function () {
    $data = ["name" => "ali"];

    $response = $this->postJson(route("users.store"), $data);

    $response->assertCreated();

    expect($response)->assertJson([
        "data" => [
            "name" => $data["name"]
        ]
    ]);
});
```

### But the Actual Pest Conversion Result is ❌
Regrettably, the generated Pest code is not as expected:

```php
<?php

test('can store user data', function () {
    $data = ["name" => "ali"];

    $response = $this->postJson(route("users.store"), $data);

    $response->assertCreated();

    expect([
        "data" => [
            "name" => $data["name"]
        ]
    ])->toBeJson();  // 👈️ This is incorrect!
});
```

### Why Did This Issue Occur?
This issue arises because Pest has introduced some assertions with names identical to those in both Laravel and PHPUnit, causing conflicts. This leads to unexpected behavior when transitioning to Pest syntax (Expectations), as demonstrated by the example above.

## (PR) Solution!

I'm thrilled to inform you that I've identified a solution to resolve the problem present in this merge request. Please take a moment to review the proposed changes and provide your feedback. Let's collaborate to ensure that our tests continue to run smoothly and our codebase remains robust.

Thanks for your attention and support! :raised_hands: