### PR TITLE
fix: preserve semicolons in group use after conversion

### DIFF
--- a/src/Parser/PrettyPrinter/Standard.php
+++ b/src/Parser/PrettyPrinter/Standard.php
@@ -32,6 +32,11 @@ final class Standard extends BaseStandard
             return $this->pFallback($node);
         }
 
+        // Don't preserve formatting for GroupUse since it can lead to SyntaxError
+        if ($node instanceof Node\Stmt\GroupUse) {
+            return parent::pStmt_GroupUse($node);
+        }
+
         return parent::p($node, $parentFormatPreserved);
     }
 

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -1391,3 +1391,25 @@ CODE;
 
     expect($convertedCode)->not->toContain('MyManager');
 });
+
+it('keep semicolon on group use after conversion', function () {
+    $code = <<<'CODE'
+<?php
+
+namespace My\Tests;
+
+use My\{Foo, Bar};
+use My\{Hello, World};
+
+class ResultTest extends TestCase
+{
+
+}
+CODE;
+
+    $convertedCode = codeConverter()->convert($code);
+
+    expect($convertedCode)
+        ->toContain("use My\{Foo, Bar};")
+        ->toContain("use My\{Hello, World};");
+});


### PR DESCRIPTION
Fix #28 