### PR TITLE
Fix: Do not convert assertions coming from method calls

### DIFF
--- a/src/Rules/Assertions/AbstractAssertionToExpectation.php
+++ b/src/Rules/Assertions/AbstractAssertionToExpectation.php
@@ -42,6 +42,10 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
             return null;
         }
 
+        if ($methodCall->var instanceof Expr\MethodCall) {
+            return null;
+        }
+
         return new MethodCall(
             $this->buildExpect($methodCall),
             new Identifier($this->newName),

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -982,6 +982,11 @@ class MyTest {
                 "name" => $data["name"]
             ]
         ]);
+        $this->getJson('/')->assertJson([
+            "data" => [
+                "name" => $data["name"]
+            ]
+        ]);
     }
 }
 CODE;
@@ -990,6 +995,11 @@ CODE;
 <?php
 test('non phpunit assert json', function () {
     $response->assertJson([
+        "data" => [
+            "name" => $data["name"]
+        ]
+    ]);
+    $this->getJson('/')->assertJson([
         "data" => [
             "name" => $data["name"]
         ]


### PR DESCRIPTION
Hello team,
Fantastic work on this plugin :raised_hands:.

In most Laravel projects there are assertions like this:
```php
$this->postJson('/login', [])
    ->assertStatus(200)
    ->assertJson(['message' => 'Login successful.']);
```

They keep getting converted to this:
```php
expect(['message' => 'Login successful.'])->toBeJson();
```
which is not correct. In this case, they should not be modified at all, right?

In this PR I add an extra condition to the converter to skip assertions coming from method calls. Not sure if this is the right approach, but would be happy to develop this PR further. Thank you :grin:  