### PR TITLE
Convert static method calls

### DIFF
--- a/config/rules.php
+++ b/config/rules.php
@@ -26,6 +26,12 @@ return [
             $classMethodAnalyzer
         )
     ),
+    new \Pest\Drift\Rules\ConvertStaticCall(
+        new \Pest\Drift\Parser\NodeFinder\NonTestMethodFinder(
+            new \Pest\Drift\Parser\NodeFinder\ClassMethodFinder($nodeFinder),
+            $classMethodAnalyzer
+        )
+    ),
     new \Pest\Drift\Rules\SetUpToBeforeEach($classMethodAnalyzer),
     new \Pest\Drift\Rules\SetUpBeforeClassToBeforeAll($classMethodAnalyzer),
     new \Pest\Drift\Rules\TearDownToAfterEach($classMethodAnalyzer),

--- a/src/Rules/AbstractConvertStaticCall.php
+++ b/src/Rules/AbstractConvertStaticCall.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+abstract class AbstractConvertStaticCall extends NodeVisitorAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    final public function enterNode(Node $node): void
+    {
+        //
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    final public function leaveNode(Node $node)
+    {
+        if ($node instanceof StaticCall) {
+            return $this->apply($node);
+        }
+    }
+
+    /**
+     * @return int|Node|array<Node>|null Replacement node (or special return value)
+     */
+    abstract protected function apply(StaticCall $staticCall): int|Node|array|null;
+}

--- a/src/Rules/ConvertStaticCall.php
+++ b/src/Rules/ConvertStaticCall.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Drift\Rules;
+
+use Pest\Drift\Parser\NodeFinder\NonTestMethodFinderInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+
+/**
+ * @internal
+ */
+final class ConvertStaticCall extends AbstractConvertStaticCall
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $classMethodsToConvert = [];
+
+    public function __construct(
+        private readonly NonTestMethodFinderInterface $nonTestMethodFinder,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->classMethodsToConvert = array_map(static fn (ClassMethod $classMethod): string => $classMethod->name->toString(), $this->nonTestMethodFinder->find($nodes));
+
+        return null;
+    }
+
+    protected function apply(StaticCall $staticCall): int|Node|array|null
+    {
+        if (! $staticCall->name instanceof Identifier) {
+            return null;
+        }
+        if (! in_array($staticCall->name->toString(), $this->classMethodsToConvert, true)) {
+            return null;
+        }
+
+        return new FuncCall(
+            new Name($staticCall->name->toString()),
+            $staticCall->getArgs(),
+            $staticCall->getAttributes()
+        );
+    }
+}

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -188,6 +188,27 @@ it('convert non test method', function () {
         ->not->toContain('$this->thisIsNotATest()');
 });
 
+it('convert non test static method calls', function () {
+    $code = '<?php
+        class MyTest {
+            protected static function thisIsNotATest() {}
+
+            public function test_non_test_method()
+            {
+                self::thisIsNotATest();
+            }
+        }
+    ';
+
+    $convertedCode = codeConverter()->convert($code);
+
+    expect($convertedCode)
+        ->toContain('function thisIsNotATest()')
+        ->not->toContain('protected function thisIsNotATest()')
+        ->toContain('thisIsNotATest();')
+        ->not->toContain('self::thisIsNotATest()');
+});
+
 it('remove properties', function () {
     $code = '<?php
         class MyTest {

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -204,7 +204,7 @@ it('convert non test static method calls', function () {
 
     expect($convertedCode)
         ->toContain('function thisIsNotATest()')
-        ->not->toContain('protected function thisIsNotATest()')
+        ->not->toContain('protected static function thisIsNotATest()')
         ->toContain('thisIsNotATest();')
         ->not->toContain('self::thisIsNotATest()');
 });


### PR DESCRIPTION
The plugin currently converts all non-test class methods (static or not) into functions. Alongside them it also converts the method calls into function calls. The static calls are, however, not changed, which causes broken tests.

This PR adds a new ConvertStaticCall rule, which is identical to ConvertMethodCall. The new rule seems to be enough to fix this problem.