### PR TITLE
DataProviderExternal Conversion support (partially, for the simplest cases)

### DIFF
--- a/src/NodeDecorator/DataProviderDecorator.php
+++ b/src/NodeDecorator/DataProviderDecorator.php
@@ -32,7 +32,12 @@ final class DataProviderDecorator extends NodeVisitorAbstract
         foreach ($classMethods as $classMethod) {
             $phpDocTags = $this->phpDocTagExtractor->fromComments($classMethod->getComments());
             $attributeGroups = $this->classMethodAnalyzer->reduceAttrGroups($classMethod);
-            $dataProviders = $attributeGroups[\Pest\Drift\ValueObject\PhpUnit\AttributeKey::DATA_PROVIDER] ?? ($phpDocTags[TagKey::DATA_PROVIDER] ?? []);
+            $dataProviders = $attributeGroups[\Pest\Drift\ValueObject\PhpUnit\AttributeKey::DATA_PROVIDER] ??
+                            $attributeGroups[\Pest\Drift\ValueObject\PhpUnit\AttributeKey::DATA_PROVIDER_EXTERNAL] ??
+                            $phpDocTags[TagKey::DATA_PROVIDER] ??
+                            $phpDocTags[TagKey::DATA_PROVIDER_EXTERNAL] ??
+                            [];
+
             $this->dataProviders = [...$this->dataProviders, ...$dataProviders];
         }
 

--- a/src/Rules/AttributeAnnotations/ConvertDataProvider.php
+++ b/src/Rules/AttributeAnnotations/ConvertDataProvider.php
@@ -15,7 +15,11 @@ final class ConvertDataProvider extends AbstractConvertAttributeAnnotation
 
     protected function getArguments(array $phpDocTags, array $attributeGroups): array
     {
-        $dataProviders = $attributeGroups[AttributeKey::DATA_PROVIDER] ?? ($phpDocTags[TagKey::DATA_PROVIDER] ?? []);
+        $dataProviders = $attributeGroups[AttributeKey::DATA_PROVIDER] ??
+                        $attributeGroups[AttributeKey::DATA_PROVIDER_EXTERNAL] ??
+                        $phpDocTags[TagKey::DATA_PROVIDER] ??
+                        $phpDocTags[TagKey::DATA_PROVIDER_EXTERNAL] ??
+                        [];
 
         return array_map(fn ($datasetName): Arg => new Arg(new String_($datasetName)), $dataProviders);
     }

--- a/src/ValueObject/PhpUnit/AttributeKey.php
+++ b/src/ValueObject/PhpUnit/AttributeKey.php
@@ -12,5 +12,7 @@ final class AttributeKey
 
     public const DATA_PROVIDER = 'DataProvider';
 
+    public const DATA_PROVIDER_EXTERNAL = 'DataProviderExternal';
+
     public const GROUP = 'Group';
 }

--- a/src/ValueObject/PhpUnit/TagKey.php
+++ b/src/ValueObject/PhpUnit/TagKey.php
@@ -12,5 +12,7 @@ final class TagKey
 
     public const DATA_PROVIDER = '@dataProvider';
 
+    public const DATA_PROVIDER_EXTERNAL = '@dataProviderExternal';
+
     public const GROUP = '@group';
 }

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -424,6 +424,37 @@ dataset(\'emailProvider\', function () {
     expect($convertedCode)->toEqual($expected);
 });
 
+it('convert external data providers to dataset', function (string $attribute) {
+    $code = <<<CODE
+<?php
+
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+
+class ExampleTest extends TestCase
+{
+    $attribute
+    public function testHasEmails(string \$email)
+    {
+    }
+}
+
+final class ExternalProviders {
+    public static function emailProvider()
+    {
+        return ["example@example.com", "other@example.com"];
+    }
+}
+CODE;
+
+    $convertedCode = codeConverter()->convert($code);
+
+    expect($convertedCode)->toContain("->with('emailProvider');")->toContain("dataset('emailProvider', function");
+})->with([
+    'DataProviderExternal Attribute' => "#[DataProviderExternal(ExternalProviders::class, 'emailProvider')]",
+    'phpDoc Tag' => "/**\n    * @dataProviderExternal emailProvider\n    */",
+]);
+
 it('convert data providers to dataset from attribute', function () {
     $code = '<?php
 


### PR DESCRIPTION
Partially fix #37, only if the external DataProvider is on the same file (like the official example from PHPUnit doc.).

For most cases, it won't be enough, as a mechanism to move providers into a Datasets.php file is needed, which is more complex and arbitrary.

But, at least, for theses cases, the with() method with a good parameter will be added, it's can help users to finish manually the conversion.
Actually, the dataProvider was completly ignored, wich is worse because the logic is silently removed. Now it's works on some case, or throws an error (when running tests) in others cases.