### PR TITLE
Improve function name conversion to description

### DIFF
--- a/src/Rules/ConvertTestMethod.php
+++ b/src/Rules/ConvertTestMethod.php
@@ -78,7 +78,7 @@ final class ConvertTestMethod extends AbstractConvertClassMethod
     private function methodNameToDescription(string $name): string
     {
         $newName = (string) preg_replace(
-            ['/^(test|it)/', '/_/', '/(?=[A-Z])/'],
+            ['/^(test|it)/', '/(?<![A-Z]|_)(?=[A-Z])/', '/_(?<![A-Z])/'],
             ['', ' ', ' '],
             $name
         );

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -109,6 +109,10 @@ it('convert phpunit class method to pest function call', function () {
 
             public function testFalseIsFalse() {}
 
+            public function testPHP8() {}
+
+            public function testPHP_IS_Great() {}
+
             /** @test */
             public function it_works() {}
         }
@@ -119,6 +123,8 @@ it('convert phpunit class method to pest function call', function () {
     expect($convertedCode)
         ->toContain("test('true is true', function () {")
         ->toContain("test('false is false', function () {")
+        ->toContain("test('php8', function () {")
+        ->toContain("test('php is great', function () {")
         ->toContain("it('works', function () {")
         ->not->toContain('/** @test */');
 });


### PR DESCRIPTION
testA77_With_Implicit -> `a77 with implicit` instead of `a77  with  implicit`

testCPO1 -> `cpo1` instead of `c p o1`