### PR TITLE
Inverse argument order for `assertThat` rule

### DIFF
--- a/src/Rules/Assertions/AbstractAssertionToExpectation.php
+++ b/src/Rules/Assertions/AbstractAssertionToExpectation.php
@@ -62,6 +62,15 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
         );
     }
 
+    private function getActualPosition(): int
+    {
+        if ($this->oldName === 'assertThat') {
+            return 0;
+        }
+
+        return $this->argumentCount >= 3 ? 1 : 0;
+    }
+
     /**
      * Extract the expected arguments.
      *
@@ -70,7 +79,7 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
      */
     private function expected(array $args): array
     {
-        $actualPosition = $this->argumentCount >= 3 ? 1 : 0;
+        $actualPosition = $this->getActualPosition();
 
         unset($args[$actualPosition]);
 
@@ -84,7 +93,7 @@ abstract class AbstractAssertionToExpectation extends AbstractConvertMethodCall
      */
     private function actual(array $args): Arg|VariadicPlaceholder
     {
-        $actualPosition = $this->argumentCount >= 3 ? 1 : 0;
+        $actualPosition = $this->getActualPosition();
 
         $actualArgument = $args[$actualPosition];
 

--- a/tests/Converters/CodeConverterTest.php
+++ b/tests/Converters/CodeConverterTest.php
@@ -1213,7 +1213,7 @@ it('convert assertThat to PestExpectation', function () {
         class MyTest {
             public function test_assert_that()
             {
-                $this->assertThat(new IsTrue(), true);
+                $this->assertThat(true, new IsTrue());
             }
         }
     ';


### PR DESCRIPTION
Hello,

Unlike other methods, the `assertThat` method takes the value to be tested (actual) as the first parameter and the expected value as the second parameter in the form of a constraint.

This is stated in the method’s documentation: https://docs.phpunit.de/en/10.5/assertions.html#assertthat

Feel free to let me know if you think a different implementation would be better.

Best regards






